### PR TITLE
Update links in package.json

### DIFF
--- a/packages/express-fineuploader-traditional-middleware/package.json
+++ b/packages/express-fineuploader-traditional-middleware/package.json
@@ -16,14 +16,14 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/FineUploader/connect-fineuploader-traditional-middleware.git"
+    "url": "git+https://github.com/feltnerm/express-fineuploader.git"
   },
   "author": "Mark Feltner",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/FineUploader/connect-fineuploader-traditional-middleware/issues"
+    "url": "https://github.com/feltnerm/express-fineuploader/issues"
   },
-  "homepage": "https://github.com/FineUploader/connect-fineuploader-traditional-middleware#readme",
+  "homepage": "https://github.com/feltnerm/express-fineuploader/tree/master/packages/express-fineuploader-traditional-middleware#readme",
   "dependencies": {
     "body-parser": "^1.15.2",
     "combined-stream": "^1.0.5",


### PR DESCRIPTION
I realize that you are part of the FineUploader team, but right now link from  [this package](https://www.npmjs.com/package/express-fineuploader-traditional-middleware) leads to 404 page in github and it confuses users like me:)
May be it would be better to change this link back later, when you really push this package to your organization repo instead of misguiding developers now?